### PR TITLE
Fix API pagination with search

### DIFF
--- a/app/Models/Traits/SearchableTrait.php
+++ b/app/Models/Traits/SearchableTrait.php
@@ -34,10 +34,11 @@ trait SearchableTrait
             return $query;
         }
 
-        if (!array_intersect(array_keys($search), $this->searchable)) {
+        $allowed_search = array_intersect_key($search, array_flip($this->searchable));
+        if (! $allowed_search) {
             return $query;
         }
 
-        return $query->where($search);
+        return $query->where($allowed_search);
     }
 }

--- a/tests/Api/IncidentTest.php
+++ b/tests/Api/IncidentTest.php
@@ -39,6 +39,60 @@ class IncidentTest extends AbstractApiTestCase
         $response->assertJsonFragment(['id' => $incidents[2]->id]);
     }
 
+    public function test_can_get_paginated_all_incidents()
+    {
+        $incidents = factory(Incident::class, 3)->create();
+
+        $response = $this->json('GET', '/api/v1/incidents?per_page=1&page=1');
+
+        $response->assertStatus(200);
+
+        $response->assertJsonFragment(['id' => $incidents[0]->id]);
+        $response->assertJsonCount(1, 'data');
+
+        $response = $this->json('GET', '/api/v1/incidents?per_page=1&page=2');
+
+        $response->assertStatus(200);
+
+        $response->assertJsonFragment(['id' => $incidents[1]->id]);
+        $response->assertJsonCount(1, 'data');
+    }
+
+    public function test_can_get_all_incidents_with_search()
+    {
+        factory(Incident::class, 3)->create([
+            'status' => 0
+        ]);
+        $incidents = factory(Incident::class, 2)->create([
+            'status' => 1
+        ]);
+
+        $response = $this->json('GET', '/api/v1/incidents?status=1');
+
+        $response->assertStatus(200);
+
+        $response->assertJsonFragment(['id' => $incidents[0]->id]);
+        $response->assertJsonFragment(['id' => $incidents[1]->id]);
+        $response->assertJsonCount(2, 'data');
+    }
+
+    public function test_can_get_paginated_all_incidents_with_search()
+    {
+        factory(Incident::class, 3)->create([
+            'status' => 0
+        ]);
+        $incidents = factory(Incident::class, 2)->create([
+            'status' => 1
+        ]);
+
+        $response = $this->json('GET', '/api/v1/incidents?status=1&page=1&per_page=1');
+
+        $response->assertStatus(200);
+
+        $response->assertJsonFragment(['id' => $incidents[0]->id]);
+        $response->assertJsonCount(1, 'data');
+    }
+
     public function test_cannot_get_invalid_component()
     {
         $response = $this->json('GET', '/api/v1/incidents/0');


### PR DESCRIPTION
API Search wasn't working with pagination as the `page` query param ended up in the DB query and as a result it would throw an error. This ensures only query params matching the allowed searchable columns gets through.