### PR TITLE
#4 component order breaking tags

### DIFF
--- a/app/Http/Controllers/Dashboard/ApiController.php
+++ b/app/Http/Controllers/Dashboard/ApiController.php
@@ -68,18 +68,8 @@ class ApiController extends AbstractApiController
             try {
                 $component = Component::find($componentId);
 
-                execute(new UpdateComponentCommand(
-                    $component,
-                    $component->name,
-                    $component->description,
-                    $component->status,
-                    $component->link,
-                    $order + 1,
-                    $component->group_id,
-                    $component->enabled,
-                    $component->meta,
-                    true
-                ));
+                $component->order = $order + 1;
+                $component->save();
             } catch (QueryException $e) {
                 throw new BadRequestHttpException();
             }

--- a/tests/Dashboard/ApiTest.php
+++ b/tests/Dashboard/ApiTest.php
@@ -1,0 +1,70 @@
+<?php
+
+/*
+ * This file is part of Cachet.
+ *
+ * (c) Alt Three Services Limited
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace CachetHQ\Tests\Cachet\Dashboard;
+
+use CachetHQ\Cachet\Bus\Events\Component\ComponentStatusWasChangedEvent;
+use CachetHQ\Cachet\Bus\Events\Component\ComponentWasCreatedEvent;
+use CachetHQ\Cachet\Bus\Events\Component\ComponentWasRemovedEvent;
+use CachetHQ\Cachet\Bus\Events\Component\ComponentWasUpdatedEvent;
+use CachetHQ\Cachet\Models\Component;
+use CachetHQ\Tests\Cachet\Api\AbstractApiTestCase;
+
+/**
+ * This is the Dashboard API test class.
+ */
+class ApiTest extends AbstractApiTestCase
+{
+    public function test_can_reorder_components()
+    {
+        $this->beUser();
+
+        $components = array();
+        $components[] = factory(Component::class)->create(['id' => 1]);
+        $components[] = factory(Component::class)->create(['id' => 2]);
+        $components[] = factory(Component::class)->create(['id' => 3]);
+
+
+        $response = $this->json('POST', '/dashboard/api/components/order', [
+            'ids'        => [
+                0 => "3",
+                1 => "1",
+                2 => "2"
+            ]
+        ]);
+
+        $this->assertEquals(2, Component::find(1)->order);
+        $this->assertEquals(3, Component::find(2)->order);
+        $this->assertEquals(1, Component::find(3)->order);
+    }
+
+    public function test_reordering_components_retains_tags()
+    {
+        $this->beUser();
+
+        $components = array();
+        $components[] = factory(Component::class)->create(['id' => 1]);
+        $components[] = factory(Component::class)->create(['id' => 2]);
+        $components[0]->attachTags(['Internal']);
+        $components[1]->attachTags(['Foo', 'Bar']);
+
+
+        $response = $this->json('POST', '/dashboard/api/components/order', [
+            'ids'        => [
+                0 => "2",
+                1 => "1",
+            ]
+        ]);
+
+        $this->assertEquals("Internal", Component::find(1)->tags[0]->name);
+        $this->assertEquals(2, Component::find(1)->order);
+    }
+}


### PR DESCRIPTION
When reordering components all components had their tags set to "1" afterwards.