### PR TITLE
Don't use last component group id for "other" section on subscription page

### DIFF
--- a/app/Http/Controllers/SubscribeController.php
+++ b/app/Http/Controllers/SubscribeController.php
@@ -67,7 +67,7 @@ class SubscribeController extends Controller
     public function showSubscribe()
     {
         return View::make('subscribe.subscribe')
-            ->withAboutApp(Markdown::convertToHtml(Config::get('setting.app_about')));
+            ->withAboutApp(Markdown::convertToHtml(Config::get('setting.app_about', '')));
     }
 
     /**

--- a/resources/views/subscribe/manage.blade.php
+++ b/resources/views/subscribe/manage.blade.php
@@ -45,9 +45,9 @@
                 <div class="list-group-item group-name">
                     <strong>{{ trans('cachet.components.group.other') }}</strong>
                     <div class="pull-right text-muted small">
-                        <a href="javascript: void(0);" class="select-group" id="select-all-{{$componentGroup->id}}">{{ trans('cachet.components.select_all') }}</a>
+                        <a href="javascript: void(0);" class="select-group" id="select-all-ungrouped">{{ trans('cachet.components.select_all') }}</a>
                         &nbsp;|&nbsp;
-                        <a href="javascript: void(0);" class="deselect-group" id="deselect-all-{{$componentGroup->id}}">{{ trans('cachet.components.deselect_all') }}</a>
+                        <a href="javascript: void(0);" class="deselect-group" id="deselect-all-ungrouped">{{ trans('cachet.components.deselect_all') }}</a>
                     </div>
                 </div>
                 @foreach($ungroupedComponents as $component)


### PR DESCRIPTION
Otherwise this breaks then there aren't any component groups as it
cannot use the last value the var was assigned as it never happened. #8