### PR TITLE
Remove extra characters on previous / next button

### DIFF
--- a/resources/lang/fr/pagination.php
+++ b/resources/lang/fr/pagination.php
@@ -22,7 +22,7 @@ return [
     |
     */
 
-    'previous' => '&laquo; Précédent',
-    'next'     => 'Suivant &raquo;',
+    'previous' => 'Précédent',
+    'next'     => 'Suivant',
 
 ];


### PR DESCRIPTION
Remove extra characters on previous / next button on the french translation