### PR TITLE
Only send verify OR manage subscription email to new subscribers #22

### DIFF
--- a/app/Http/Controllers/SubscribeController.php
+++ b/app/Http/Controllers/SubscribeController.php
@@ -90,8 +90,10 @@ class SubscribeController extends Controller
                 ->withErrors($e->getMessageBag());
         }
 
-        // Send the subscriber a link to manage their subscription.
-        $subscription->notify(new ManageSubscriptionNotification());
+        if ($verified) {
+            // Send the subscriber a link to manage their subscription.
+            $subscription->notify(new ManageSubscriptionNotification());
+        }
 
         return redirect()->back()->withSuccess(
             sprintf(

--- a/tests/SmokeTest.php
+++ b/tests/SmokeTest.php
@@ -17,6 +17,7 @@ use CachetHQ\Cachet\Models\Setting;
 use Illuminate\Foundation\Testing\DatabaseMigrations;
 use Illuminate\Support\Facades\Notification;
 use CachetHQ\Cachet\Notifications\Subscriber\VerifySubscriptionNotification;
+use CachetHQ\Cachet\Notifications\Subscriber\ManageSubscriptionNotification;
 use CachetHQ\Cachet\Models\Subscriber;
 use Illuminate\Support\Facades\URL;
 
@@ -68,6 +69,10 @@ class SmokeTest extends AbstractTestCase
         Notification::assertSentTo(
             [$subscriber],
             VerifySubscriptionNotification::class
+        );
+        Notification::assertNotSentTo(
+            [$subscriber],
+            ManageSubscriptionNotification::class
         );
 
         $verify_route = URL::signedRoute(cachet_route_generator('subscribe.verify'), ['code' => $subscriber->verify_code]);


### PR DESCRIPTION
Users don't really need both a verify and manage email when they first subscribe so only send verify unless the setting for no requiring verification is set at which point send them the manage subscription email.