### PR TITLE
Improve 2.3 -> 2.5 upgrade process

### DIFF
--- a/database/migrations/2016_07_25_052444_AlterTableComponentGroupsAddVisibleColumn.php
+++ b/database/migrations/2016_07_25_052444_AlterTableComponentGroupsAddVisibleColumn.php
@@ -26,7 +26,7 @@ class AlterTableComponentGroupsAddVisibleColumn extends Migration
             $table->tinyInteger('visible')
                 ->after('order')
                 ->unsigned()
-                ->default(\CachetHQ\Cachet\Models\ComponentGroup::VISIBLE_AUTHENTICATED);
+                ->default(\CachetHQ\Cachet\Models\ComponentGroup::VISIBLE_GUEST);
 
             $table->index('visible');
         });

--- a/database/migrations/2016_10_30_182324_AlterTableIncidentsRemoveScheduledColumns.php
+++ b/database/migrations/2016_10_30_182324_AlterTableIncidentsRemoveScheduledColumns.php
@@ -14,6 +14,8 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
+use Carbon\Carbon;
+use CachetHQ\Cachet\Models\Schedule;
 
 class AlterTableIncidentsRemoveScheduledColumns extends Migration
 {
@@ -24,6 +26,7 @@ class AlterTableIncidentsRemoveScheduledColumns extends Migration
      */
     public function up()
     {
+        $yesterday = Carbon::now()->subDay();
         // We need a better way of handling data migrations...
         $system = app(System::class);
         $prefix = $system->getTablePrefix();
@@ -34,6 +37,20 @@ class AlterTableIncidentsRemoveScheduledColumns extends Migration
         Schema::table('incidents', function (Blueprint $table) {
             $table->dropColumn('scheduled_at');
         });
+
+        // Close schedules older than a day
+        $old_schedules = DB::table('schedules')
+            ->where('scheduled_at', '<', $yesterday)
+            ->get();
+
+        foreach ($old_schedules as $schedule) {
+            DB::table('schedules')
+                ->where('id', $schedule->id)
+                ->update([
+                    'completed_at' => $schedule->scheduled_at,
+                    'status' => Schedule::COMPLETE
+                ]);
+        }
     }
 
     /**
@@ -46,5 +63,8 @@ class AlterTableIncidentsRemoveScheduledColumns extends Migration
         Schema::table('incidents', function (Blueprint $table) {
             $table->timestamp('scheduled_at')->before('created_at')->nullable()->default(null);
         });
+        $system = app(System::class);
+        $prefix = $system->getTablePrefix();
+        DB::update("INSERT INTO {$prefix}incidents (name, status, message, scheduled_at, created_at, updated_at) SELECT name, 0, message, scheduled_at, created_at, updated_at FROM {$prefix}schedules");
     }
 }


### PR DESCRIPTION
* 2.3 does not have the ability to make component groups visible only to authenticated users. So defaulting to making component groups public so your existing component groups don't suddenly disappear from your public status page when updating.
* 2.3 does not have a completed_at time for maintenance so when migrated to 2.5 they all appear as still open (i.e in progress) and so show up on the status page, not very nice if you have lots of these and have been using Cachet for many years. So closing all maintenance schedules which were meant to start over a day ago. This should mean any in progress now won't get closed automatically before their time. 