### PR TITLE
add blank signature template file, added to all email notifications

### DIFF
--- a/resources/views/notifications/partials/subscription.blade.php
+++ b/resources/views/notifications/partials/subscription.blade.php
@@ -1,3 +1,5 @@
+@include('notifications.partials.signature')
+
 @component('mail::subcopy')
 [{{ $unsubscribeText }}]({{ $unsubscribeUrl }}) &mdash; [{{ $manageSubscriptionText }}]({{ $manageSubscriptionUrl }})
 @endcomponent

--- a/resources/views/vendor/notifications/email.blade.php
+++ b/resources/views/vendor/notifications/email.blade.php
@@ -46,6 +46,8 @@
 @lang('Regards'),<br>{{ setting('app_name', config('app.name')) }}
 @endif
 
+@include('notifications.partials.signature')
+
 {{-- Subcopy --}}
 @isset($actionText)
 @component('mail::subcopy')


### PR DESCRIPTION
This allows for a simple method to include an email signature to all outgoing notifications. the blank file will avoid local customizations to be overridden.