### PR TITLE
add configurable email signature for all outgoing mail notifications

### DIFF
--- a/app/Http/Controllers/Dashboard/SettingsController.php
+++ b/app/Http/Controllers/Dashboard/SettingsController.php
@@ -333,6 +333,17 @@ class SettingsController extends Controller
 
         execute(new UpdateConfigCommand($config));
 
+        $setting = app(Repository::class);
+        $parameters = Binput::get('setting');
+
+        if (isset($parameters['mail_signature'])) {
+            if ($mail_signature = Binput::get('setting.mail_signature', null, false, false)) {
+                $setting->set('mail_signature', $mail_signature);
+            } else {
+                $setting->delete('mail_signature');
+            }
+        }
+
         return cachet_redirect('dashboard.settings.mail')
             ->withInput(Binput::all())
             ->withSuccess(trans('dashboard.notifications.awesome'));

--- a/resources/lang/de-DE/dashboard.php
+++ b/resources/lang/de-DE/dashboard.php
@@ -233,6 +233,7 @@ return [
                 'subject' => 'Test-Benachrichtigung von Cachet',
                 'body'    => 'Dies ist eine Test-Benachrichtigung von Cachet.',
             ],
+            'signature'      => 'Benutzerdefinierte HTML E-Mail Signatur',
         ],
         'security' => [
             'security'   => 'Sicherheit',

--- a/resources/lang/en/dashboard.php
+++ b/resources/lang/en/dashboard.php
@@ -233,6 +233,7 @@ return [
                 'subject' => 'Test notification from Cachet',
                 'body'    => 'This is a test notification from Cachet.',
             ],
+            'signature'      => 'Custom HTML E-Mail Signature',
         ],
         'security' => [
             'security'   => 'Security',

--- a/resources/views/dashboard/settings/mail.blade.php
+++ b/resources/views/dashboard/settings/mail.blade.php
@@ -40,6 +40,10 @@
                             <label>{{ trans('forms.setup.mail_password') }}</label>
                             <input type="password" class="form-control" name="config[mail_password]" value="{{ Binput::old('config.mail_password') }}" autocomplete="off" placeholder="{{ trans('forms.setup.mail_password') }}">
                         </div>
+                        <div class="form-group">
+                            <label>{{ trans('dashboard.settings.mail.signature') }}</label>
+                            <textarea name="setting[mail_signature]" class="form-control" rows="10" placeholder="{{ trans('dashboard.settings.mail.signature') }}">{{ Config::get('setting.mail_signature') }}</textarea>
+                        </div>
                     </fieldset>
 
                     <div class="row">

--- a/resources/views/notifications/incident/new.blade.php
+++ b/resources/views/notifications/incident/new.blade.php
@@ -10,6 +10,7 @@
 @lang('Thanks,')<br>
 {{ Config::get('setting.app_name') }}
 
+{!! Config::get('setting.mail_signature') !!}
 @include('notifications.partials.subscription')
 
 @endcomponent

--- a/resources/views/notifications/partials/subscription.blade.php
+++ b/resources/views/notifications/partials/subscription.blade.php
@@ -1,3 +1,5 @@
+{!! Config::get('setting.mail_signature') !!}
+
 @component('mail::subcopy')
 [{{ $unsubscribeText }}]({{ $unsubscribeUrl }}) &mdash; [{{ $manageSubscriptionText }}]({{ $manageSubscriptionUrl }})
 @endcomponent

--- a/resources/views/vendor/notifications/email.blade.php
+++ b/resources/views/vendor/notifications/email.blade.php
@@ -46,6 +46,8 @@
 @lang('Regards'),<br>{{ setting('app_name', config('app.name')) }}
 @endif
 
+{!! Config::get('setting.mail_signature') !!}
+
 {{-- Subcopy --}}
 @isset($actionText)
 @component('mail::subcopy')


### PR DESCRIPTION
let me know if this `{!! Config::get('setting.mail_signature') !!}` is no good. I'll then add a mail_stylesheet option, too.