### PR TITLE
Email template translation

### DIFF
--- a/resources/lang/de-DE/notifications.php
+++ b/resources/lang/de-DE/notifications.php
@@ -13,6 +13,7 @@ return [
     'common' => [
         'salutation'       => 'Viele Grüße,',
         'alternative_link' => 'Sollten Sie Probleme mit der ":actionText" Schaltfläche haben, können Sie auch die folgende URL in Ihren Browser kopieren: :actionURL',
+        'copyright_notice' => 'Alle Rechte vorbehalten.',
     ],
     'component' => [
         'status_update' => [

--- a/resources/lang/de-DE/notifications.php
+++ b/resources/lang/de-DE/notifications.php
@@ -10,6 +10,9 @@
  */
 
 return [
+    'common' => [
+        'salutation' => 'Viele Grüße,',
+    ],
     'component' => [
         'status_update' => [
             'mail' => [

--- a/resources/lang/de-DE/notifications.php
+++ b/resources/lang/de-DE/notifications.php
@@ -11,7 +11,8 @@
 
 return [
     'common' => [
-        'salutation' => 'Viele Grüße,',
+        'salutation'       => 'Viele Grüße,',
+        'alternative_link' => 'Sollten Sie Probleme mit der ":actionText" Schaltfläche haben, können Sie auch die folgende URL in Ihren Browser kopieren: :actionURL',
     ],
     'component' => [
         'status_update' => [

--- a/resources/lang/en/notifications.php
+++ b/resources/lang/en/notifications.php
@@ -11,7 +11,8 @@
 
 return [
     'common' => [
-        'salutation' => 'Thanks,',
+        'salutation'       => 'Thanks,',
+        'alternative_link' => 'If you\'re having trouble clicking the ":actionText" button, copy and paste the URL below into your web browser: :actionURL',
     ],
     'component' => [
         'status_update' => [

--- a/resources/lang/en/notifications.php
+++ b/resources/lang/en/notifications.php
@@ -10,6 +10,9 @@
  */
 
 return [
+    'common' => [
+        'salutation' => 'Thanks,',
+    ],
     'component' => [
         'status_update' => [
             'mail' => [

--- a/resources/lang/en/notifications.php
+++ b/resources/lang/en/notifications.php
@@ -13,6 +13,7 @@ return [
     'common' => [
         'salutation'       => 'Thanks,',
         'alternative_link' => 'If you\'re having trouble clicking the ":actionText" button, copy and paste the URL below into your web browser: :actionURL',
+        'copyright_notice' => 'All rights reserved.',
     ],
     'component' => [
         'status_update' => [

--- a/resources/views/notifications/component/update.blade.php
+++ b/resources/views/notifications/component/update.blade.php
@@ -3,7 +3,7 @@
 
 {{ $content }}
 
-@lang('Thanks,')<br>
+{{ trans('notifications.common.salutation') }}<br>
 {{ Config::get('setting.app_name') }}
 
 @include('notifications.partials.subscription')

--- a/resources/views/notifications/incident/new.blade.php
+++ b/resources/views/notifications/incident/new.blade.php
@@ -7,7 +7,7 @@
 {{ $actionText }}
 @endcomponent
 
-@lang('Thanks,')<br>
+{{ trans('notifications.common.salutation') }}<br>
 {{ Config::get('setting.app_name') }}
 
 @include('notifications.partials.subscription')

--- a/resources/views/notifications/incident/update.blade.php
+++ b/resources/views/notifications/incident/update.blade.php
@@ -7,7 +7,7 @@
 {{ $actionText }}
 @endcomponent
 
-@lang('Thanks,')<br>
+{{ trans('notifications.common.salutation') }}<br>
 {{ Config::get('setting.app_name') }}
 
 @include('notifications.partials.subscription')

--- a/resources/views/notifications/schedule/new.blade.php
+++ b/resources/views/notifications/schedule/new.blade.php
@@ -3,7 +3,7 @@
 
 {{ $content }}
 
-@lang('Thanks,')<br>
+{{ trans('notifications.common.salutation') }}<br>
 {{ Config::get('setting.app_name') }}
 
 @include('notifications.partials.subscription')

--- a/resources/views/vendor/mail/html/message.blade.php
+++ b/resources/views/vendor/mail/html/message.blade.php
@@ -21,7 +21,7 @@
     {{-- Footer --}}
     @slot('footer')
         @component('mail::footer')
-            © {{ date('Y') }} {{ setting('app_name', config('app.name')) }}. @lang('All rights reserved.')
+            © {{ date('Y') }} {{ setting('app_name', config('app.name')) }}. {{ trans('notifications.common.copyright_notice') }}
         @endcomponent
     @endslot
 @endcomponent

--- a/resources/views/vendor/mail/markdown/message.blade.php
+++ b/resources/views/vendor/mail/markdown/message.blade.php
@@ -21,7 +21,7 @@
     {{-- Footer --}}
     @slot('footer')
         @component('mail::footer')
-            © {{ date('Y') }} {{ setting('app_name', config('app.name')) }}. @lang('All rights reserved.')
+            © {{ date('Y') }} {{ setting('app_name', config('app.name')) }}. {{ trans('notifications.common.copyright_notice') }}
         @endcomponent
     @endslot
 @endcomponent

--- a/resources/views/vendor/notifications/email.blade.php
+++ b/resources/views/vendor/notifications/email.blade.php
@@ -51,14 +51,10 @@
 {{-- Subcopy --}}
 @isset($actionText)
 @component('mail::subcopy')
-@lang(
-    "If you’re having trouble clicking the \":actionText\" button, copy and paste the URL below\n".
-    'into your web browser: [:actionURL](:actionURL)',
-    [
+{{ trans('notifications.common.alternative_link', [
         'actionText' => $actionText,
         'actionURL' => $actionUrl,
-    ]
-)
+    ]) }}
 @endcomponent
 @endisset
 @endcomponent

--- a/resources/views/vendor/notifications/email.blade.php
+++ b/resources/views/vendor/notifications/email.blade.php
@@ -43,7 +43,7 @@
 @if (! empty($salutation))
 {{ $salutation }}
 @else
-@lang('Regards'),<br>{{ setting('app_name', config('app.name')) }}
+{{ trans('notifications.common.salutation') }}<br>{{ setting('app_name', config('app.name')) }}
 @endif
 
 {!! Config::get('setting.mail_signature') !!}


### PR DESCRIPTION
the @lang() was used on full words / repentances and not in the manner expected from trans() - this removes the (active) usage of @lang in email templates in favour of trans().

Other usages, such as during the initial setup is not covered by this PR.