### PR TITLE
Fix bug metrics does not respect threshold config

### DIFF
--- a/app/Repositories/Metric/MetricRepository.php
+++ b/app/Repositories/Metric/MetricRepository.php
@@ -71,7 +71,7 @@ class MetricRepository
 
         for ($i = 0; $i < $timeframe; $i++) {
             if (!$points->has($pointKey)) {
-                if ($i >= $metric->threshold) {
+                if ($minutesWithNoData >= $metric->threshold) {
                     $points->put($pointKey, $metric->default_value);
                     //We put default value as metric, so we can reset counter for minutes without data
                     $minutesWithNoData = 0;


### PR DESCRIPTION
This commit fix the bug that even $metric->threshold is configured to a greater than 1 minute, but the metrics generated was always filled with default value to the returned metric points for every minute.